### PR TITLE
Fix wording in GstPtr README

### DIFF
--- a/GstPtr/README.md
+++ b/GstPtr/README.md
@@ -81,7 +81,7 @@ Best practice is calling it for all `[transfer::floating]` functions.
 
 `[transfer::full]` functions work as expected, but do not call `void sink()` for
 those, because some functions returning `[transfer::full]` do not clear the
-floating flag, thus causing double unref if `void sink()` is called.
+floating flag, thus causing a leak if `void sink()` is called.
 
 
 ####  Check if the function returns `[transfer::none]`


### PR DESCRIPTION
## Summary
- clarify note about `void sink()` causing leaks, not double unrefs

## Testing
- `cmake -Bbuild -DCONAN_BUILD_MISSING=ON` *(fails: Cannot install editorconfig-checker, black, pre-commit or cmakelang)*

------
https://chatgpt.com/codex/tasks/task_e_6844868287fc8332afce718f3e43e152