### PR TITLE
Update conan recipe for 0.0.3 and add test_package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+conan_recipe/* export-ignore

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ You can add this header as a Conan dependency in a few steps:
 
 ```shell
 cd conan_recipe
-conan export gstreamercpphelpers/0.0.2@
+conan export gstreamercpphelpers/0.0.3@
 ```
 
 * Include the dependency in your conanfile.txt or equivalent
 
 ```script
 [requires]
-   gstreamercpphelpers/0.0.2
+   gstreamercpphelpers/0.0.3
 ```
 
 * Use in your CMakeLists.txt

--- a/conan_recipe/conandata.yml
+++ b/conan_recipe/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "0.0.2":
     sha256: "58f1d0915a8e98c89c20c3ed462a62d3680a43014ddc00af6ceb1b7d3c491390"
     url: "https://github.com/nachogarglez/GStreamerCppHelpers/archive/refs/tags/0.0.2.tar.gz"
+  "0.0.3":
+    sha256: "8376b8ab97e7f6228b814988ccd8b204fe0ff9f3de9ff535e278a2c548c12ff2"
+    url: "https://github.com/nachogarglez/GStreamerCppHelpers/archive/refs/tags/0.0.3.tar.gz"

--- a/conan_recipe/test_package/CMakeLists.txt
+++ b/conan_recipe/test_package/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+find_package(gstreamercpphelpers REQUIRED)
+add_executable(${PROJECT_NAME} test_package.cpp)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11)
+target_link_libraries(${PROJECT_NAME} gstreamercpphelpers::gstreamercpphelpers)

--- a/conan_recipe/test_package/conanfile.py
+++ b/conan_recipe/test_package/conanfile.py
@@ -1,0 +1,20 @@
+import os
+from conan import ConanFile
+from conan.tools.cmake import cmake_layout, CMake
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not self.conf.get("tools.build:skip_test", default=False):
+            self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), env="conanrun")

--- a/conan_recipe/test_package/test_package.cpp
+++ b/conan_recipe/test_package/test_package.cpp
@@ -1,0 +1,4 @@
+#include <GstPtr/gst_ptr.h>
+int main() {
+    return 0;
+}


### PR DESCRIPTION
## Summary
- ignore recipe from release archives
- bump README instructions to version `0.0.3`
- add `0.0.3` download information
- provide a minimal `test_package` for Conan packages

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCONAN_BUILD_MISSING=ON`
- `cmake --build build`
- `cmake --build build --target test`


------
https://chatgpt.com/codex/tasks/task_e_6844c807752883329311e248dc1f0289