### PR TITLE
Add GstContext type to GstPtr

### DIFF
--- a/GstPtr/gst_ptr.h
+++ b/GstPtr/gst_ptr.h
@@ -231,6 +231,7 @@ struct IGstBus : IGstObject {};
 struct IGstCaps : IGstMiniObject {};
 struct IGstBuffer : IGstMiniObject {};
 struct IGstEvent : IGstMiniObject {};
+struct IGstContext : IGstMiniObject {};
 
 struct IGParamSpec {
   template <typename T> static void ref(T *ptr) noexcept {
@@ -272,6 +273,7 @@ GST_PTR_MAP_INTERFACE_WITH_TYPE(GstPipeline, GST_TYPE_PIPELINE)
 GST_PTR_MAP_INTERFACE_WITH_TYPE(GstCaps, GST_TYPE_CAPS)
 GST_PTR_MAP_INTERFACE_WITH_TYPE(GstBuffer, GST_TYPE_BUFFER)
 GST_PTR_MAP_INTERFACE_WITH_TYPE(GstEvent, GST_TYPE_EVENT)
+GST_PTR_MAP_INTERFACE_WITH_TYPE(GstContext, GST_TYPE_CONTEXT)
 GST_PTR_MAP_INTERFACE_WITH_TYPE(GstBus, GST_TYPE_BUS)
 GST_PTR_MAP_INTERFACE_WITH_TYPE(GMainLoop, G_TYPE_NONE)
 GST_PTR_MAP_INTERFACE_WITH_TYPE(GParamSpec, G_TYPE_PARAM)

--- a/GstPtr/test/test_gst_ptr.cpp
+++ b/GstPtr/test/test_gst_ptr.cpp
@@ -19,6 +19,7 @@ constexpr GType G_TYPE_PARAM = 0x09;
 constexpr GType GST_TYPE_PAD = 0x0A;
 constexpr GType GST_TYPE_BUFFER = 0x0B;
 constexpr GType GST_TYPE_EVENT = 0x0C;
+constexpr GType GST_TYPE_CONTEXT = 0x0D;
 constexpr bool TRUE = true;
 
 struct GTypeInstance {
@@ -49,6 +50,7 @@ class GstMiniObject : public GTypeInstance {};
 class GstCaps : public GstMiniObject {};
 class GstBuffer : public GstMiniObject {};
 class GstEvent : public GstMiniObject {};
+class GstContext : public GstMiniObject {};
 struct GParamSpec : public GTypeInstance {};
 struct GMainLoop : public GTypeInstance {};
 


### PR DESCRIPTION
## Summary
- support `GstContext` with an interface and type mapping
- update unit test stubs for `GstContext`

## Testing
- `cmake -Bbuild -DCONAN_BUILD_MISSING=ON` *(fails: Cannot install editorconfig-checker, black, pre-commit or cmakelang)*

------
https://chatgpt.com/codex/tasks/task_e_6844845017188332a91b2d2adadcf0dc