### PR TITLE
Fix Visual Studio bool comparison

### DIFF
--- a/GstPtr/gst_ptr.h
+++ b/GstPtr/gst_ptr.h
@@ -433,7 +433,7 @@ public:
     using DerivedInterface = typename detail::GetInterface<toDerivedType>;
     auto mayPromote = g_type_check_instance_is_a((GTypeInstance *)m_pointer,
                                                  DerivedInterface::getGType());
-    if (mayPromote != TRUE) {
+    if (!mayPromote) {
       throw std::bad_cast();
     }
     return (toDerivedType *)g_type_check_instance_cast(

--- a/GstPtr/test/test_gst_ptr.cpp
+++ b/GstPtr/test/test_gst_ptr.cpp
@@ -19,7 +19,6 @@ constexpr GType G_TYPE_PARAM = 0x09;
 constexpr GType GST_TYPE_PAD = 0x0A;
 constexpr GType GST_TYPE_BUFFER = 0x0B;
 constexpr GType GST_TYPE_EVENT = 0x0C;
-constexpr bool TRUE = true;
 
 struct GTypeInstance {
     virtual ~GTypeInstance() = default;


### PR DESCRIPTION
## Summary
- fix bool comparison with GLib TRUE by checking `!mayPromote`
- clean up unused test constant

## Testing
- `cmake -Bbuild -DCONAN_BUILD_MISSING=ON` *(fails: Cannot install editorconfig-checker, black, pre-commit or cmakelang)*

------
https://chatgpt.com/codex/tasks/task_e_684488fe0cf883328e4e44c90f68ff97